### PR TITLE
Accept name and description maps for updating metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,7 +1206,7 @@ dependencies = [
 
 [[package]]
 name = "pahkat-reposrv"
-version = "0.3.3"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "arc-ext",

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -124,8 +124,8 @@ fn modify_repo_metadata(
     };
 
     let inner_req = package::update::Request::builder()
-        .repo_path(path.clone().into())
-        .id(package_id.clone().into())
+        .repo_path(path.into())
+        .id(package_id.into())
         .version(Cow::Owned(version))
         .channel(release.channel.as_ref().map(|x| Cow::Borrowed(&**x)))
         .target(Cow::Borrowed(&release.target))

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -43,6 +43,8 @@ struct UpdatePackageMetadataResponse {
 
 #[derive(Object, Debug, Clone)]
 pub struct UpdatePackageMetadataRequest {
+    pub name: Option<pahkat_types::LangTagMap<String>>,
+    pub description: Option<pahkat_types::LangTagMap<String>>,
     pub version: String,
     pub channel: Option<String>,
     #[oai(default)]
@@ -126,6 +128,8 @@ fn modify_repo_metadata(
     let inner_req = package::update::Request::builder()
         .repo_path(path.into())
         .id(package_id.into())
+        .name(release.name.as_ref().map(|x| Cow::Borrowed(&*x)))
+        .description(release.description.as_ref().map(|x| Cow::Borrowed(&*x)))
         .version(Cow::Owned(version))
         .channel(release.channel.as_ref().map(|x| Cow::Borrowed(&**x)))
         .target(Cow::Borrowed(&release.target))

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -54,8 +54,8 @@ pub struct UpdatePackageMetadataRequest {
 
 #[derive(Object, Debug, Clone)]
 pub struct CreatePackageMetadataRequest {
-    pub name: String,
-    pub description: String,
+    pub name: pahkat_types::LangTagMap<String>,
+    pub description: pahkat_types::LangTagMap<String>,
     pub tags: Vec<String>,
 }
 


### PR DESCRIPTION
Adds the ability to update a repos metadata with a map of localized name and description metadata. The additional part of the payload looks like:

```json
{
...
  "name" {
    "en": "English name",
    "sv": "Swedish name"
  },
  "description": {
    "en": "English description",
    "sv": "Swedish description"
  }
...
}
```

Supplying this info will update the `index.toml` with the included names and descriptions.

[Example `index.toml`](https://github.com/divvun/pahkat.uit.no-index/blob/main/main/packages/keyboard-fit/index.toml).